### PR TITLE
Support display of available video tracks as drop-down and to swap among them

### DIFF
--- a/lib/playback/index.ts
+++ b/lib/playback/index.ts
@@ -75,7 +75,7 @@ export class Player {
 				tracks.push(track)
 			}
 		})
-		
+
 		// Call #runInit on each unique init track
 		// TODO do this in parallel with #runTrack to remove a round trip
 		await Promise.all(Array.from(inits).map((init) => this.#runInit(...init)))
@@ -153,7 +153,7 @@ export class Player {
 		}
 	}
 
-	async getVideoTracks() {
+	getVideoTracks() {
 		return this.#catalog.tracks
 		.filter(Catalog.isVideoTrack)
 		.map(track => track.name)
@@ -164,18 +164,18 @@ export class Player {
 		if (currentTrack) {
 			console.log(`Unsubscribing from track: ${currentTrack.name} and Subscribing to track: ${trackname}`)
 			await this.unsubscribeFromTrack(currentTrack.name)
-		}else{
+		} else {
 			console.log(`Subscribing to track: ${trackname}`)
 		}
+
+		this.#tracknum = this.#catalog.tracks.findIndex((track) => track.name === trackname)
 		
-		this.#tracknum = this.#catalog.tracks.findIndex(track => track.name === trackname)
-		
-		const tracksToStream = this.#catalog.tracks.filter(track => track.name === trackname)
-		
+		const tracksToStream = this.#catalog.tracks.filter((track) => track.name === trackname)
+
 		await Promise.all(tracksToStream.map((track) => this.#runTrack(track)))
 	}
 
-	async unsubscribeFromTrack(trackname: string){
+	async unsubscribeFromTrack(trackname: string) {
 		await this.#connection.unsubscribe(trackname)
 	}
 

--- a/lib/playback/index.ts
+++ b/lib/playback/index.ts
@@ -28,6 +28,7 @@ export class Player {
 
 	#connection: Connection
 	#catalog: Catalog.Root
+	#tracknum: number
 
 	// Running is a promise that resolves when the player is closed.
 	// #close is called with no error, while #abort is called with an error.
@@ -35,10 +36,11 @@ export class Player {
 	#close!: () => void
 	#abort!: (err: Error) => void
 
-	private constructor(connection: Connection, catalog: Catalog.Root, backend: Backend) {
+	private constructor(connection: Connection, catalog: Catalog.Root, backend: Backend, tracknum: number) {
 		this.#connection = connection
 		this.#catalog = catalog
 		this.#backend = backend
+		this.#tracknum = tracknum
 
 		const abort = new Promise<void>((resolve, reject) => {
 			this.#close = resolve
@@ -49,7 +51,7 @@ export class Player {
 		this.#running = Promise.race([this.#run(), abort]).catch(this.#close)
 	}
 
-	static async create(config: PlayerConfig): Promise<Player> {
+	static async create(config: PlayerConfig,tracknum: number): Promise<Player> {
 		const client = new Client({ url: config.url, fingerprint: config.fingerprint, role: "subscriber" })
 		const connection = await client.connect()
 
@@ -59,19 +61,21 @@ export class Player {
 		const canvas = config.canvas.transferControlToOffscreen()
 		const backend = new Backend({ canvas, catalog })
 
-		return new Player(connection, catalog, backend)
+		return new Player(connection, catalog, backend, tracknum)
 	}
 
 	async #run() {
 		const inits = new Set<[string, string]>()
 		const tracks = new Array<Catalog.Track>()
 
-		for (const track of this.#catalog.tracks) {
-			if (!track.namespace) throw new Error("track has no namespace")
-			if (track.initTrack) inits.add([track.namespace, track.initTrack])
-			tracks.push(track)
-		}
-
+		this.#catalog.tracks.forEach((track, index) => {
+			if (index == this.#tracknum || Catalog.isAudioTrack(track)) {
+				if (!track.namespace) throw new Error("track has no namespace")
+				if (track.initTrack) inits.add([track.namespace, track.initTrack])
+				tracks.push(track)
+			}
+		})
+		
 		// Call #runInit on each unique init track
 		// TODO do this in parallel with #runTrack to remove a round trip
 		await Promise.all(Array.from(inits).map((init) => this.#runInit(...init)))
@@ -138,6 +142,41 @@ export class Player {
 
 	getCatalog() {
 		return this.#catalog
+	}
+
+	getCurrentTrack() {
+		if (this.#tracknum >= 0 && this.#tracknum < this.#catalog.tracks.length) {
+			return this.#catalog.tracks[this.#tracknum]
+		} else {
+			console.warn("Invalid track number:", this.#tracknum)
+			return null
+		}
+	}
+
+	async getVideoTracks() {
+		return this.#catalog.tracks
+		.filter(Catalog.isVideoTrack)
+		.map(track => track.name)
+	}
+
+	async switchTrack(trackname: string) {
+		const currentTrack = this.getCurrentTrack()
+		if (currentTrack) {
+			console.log(`Unsubscribing from track: ${currentTrack.name} and Subscribing to track: ${trackname}`)
+			await this.unsubscribeFromTrack(currentTrack.name)
+		}else{
+			console.log(`Subscribing to track: ${trackname}`)
+		}
+		
+		this.#tracknum = this.#catalog.tracks.findIndex(track => track.name === trackname)
+		
+		const tracksToStream = this.#catalog.tracks.filter(track => track.name === trackname)
+		
+		await Promise.all(tracksToStream.map((track) => this.#runTrack(track)))
+	}
+
+	async unsubscribeFromTrack(trackname: string){
+		await this.#connection.unsubscribe(trackname)
 	}
 
 	#onMessage(msg: Message.FromWorker) {

--- a/lib/playback/index.ts
+++ b/lib/playback/index.ts
@@ -51,7 +51,7 @@ export class Player {
 		this.#running = Promise.race([this.#run(), abort]).catch(this.#close)
 	}
 
-	static async create(config: PlayerConfig,tracknum: number): Promise<Player> {
+	static async create(config: PlayerConfig, tracknum: number): Promise<Player> {
 		const client = new Client({ url: config.url, fingerprint: config.fingerprint, role: "subscriber" })
 		const connection = await client.connect()
 
@@ -154,9 +154,7 @@ export class Player {
 	}
 
 	getVideoTracks() {
-		return this.#catalog.tracks
-		.filter(Catalog.isVideoTrack)
-		.map(track => track.name)
+		return this.#catalog.tracks.filter(Catalog.isVideoTrack).map((track) => track.name)
 	}
 
 	async switchTrack(trackname: string) {
@@ -167,11 +165,8 @@ export class Player {
 		} else {
 			console.log(`Subscribing to track: ${trackname}`)
 		}
-
 		this.#tracknum = this.#catalog.tracks.findIndex((track) => track.name === trackname)
-		
 		const tracksToStream = this.#catalog.tracks.filter((track) => track.name === trackname)
-
 		await Promise.all(tracksToStream.map((track) => this.#runTrack(track)))
 	}
 

--- a/lib/playback/worker/video.ts
+++ b/lib/playback/worker/video.ts
@@ -76,16 +76,18 @@ export class Renderer {
 
 		const { sample, track } = frame
 
-		// Reset the decoder on track change
-		if (this.#decoderConfig) {
-			const configMismatch = 
-			this.#decoderConfig.codec !== track.codec ||
-			this.#decoderConfig.codedWidth !== track.video.width ||
-			this.#decoderConfig.codedHeight !== track.video.height
+		// Reset the decoder on video track change
+		if (this.#decoderConfig && this.#decoder.state == "configured") {
+			if (MP4.isVideoTrack(track)) {
+				const configMismatch = 
+				this.#decoderConfig.codec !== track.codec ||
+				this.#decoderConfig.codedWidth !== track.video.width ||
+				this.#decoderConfig.codedHeight !== track.video.height
 
-			if (configMismatch) {
-				this.#decoder.reset()
-				this.#decoderConfig = undefined
+				if (configMismatch) {
+					this.#decoder.reset()
+					this.#decoderConfig = undefined
+				}
 			}
 		}
 

--- a/lib/playback/worker/video.ts
+++ b/lib/playback/worker/video.ts
@@ -14,7 +14,7 @@ interface DecoderConfig {
 		transfer?: "bt709" | "smpte170m" | "iec61966-2-1"
 		matrix?: "rgb" | "bt709" | "bt470bg" | "smpte170m"
 	}
-	hardwareAcceleration?: "no-preference" | "prefer-hardware" | "prefer-software" 
+	hardwareAcceleration?: "no-preference" | "prefer-hardware" | "prefer-software"
 	optimizeForLatency?: boolean
 }
 
@@ -79,10 +79,10 @@ export class Renderer {
 		// Reset the decoder on video track change
 		if (this.#decoderConfig && this.#decoder.state == "configured") {
 			if (MP4.isVideoTrack(track)) {
-				const configMismatch = 
-				this.#decoderConfig.codec !== track.codec ||
-				this.#decoderConfig.codedWidth !== track.video.width ||
-				this.#decoderConfig.codedHeight !== track.video.height
+				const configMismatch =
+					this.#decoderConfig.codec !== track.codec ||
+					this.#decoderConfig.codedWidth !== track.video.width ||
+					this.#decoderConfig.codedHeight !== track.video.height
 
 				if (configMismatch) {
 					this.#decoder.reset()
@@ -112,9 +112,9 @@ export class Renderer {
 			}
 
 			this.#decoder.configure(this.#decoderConfig)
-			if(!frame.sample.is_sync){
+			if (!frame.sample.is_sync) {
 				this.#waitingForKeyframe = true
-			}else{
+			} else {
 				this.#waitingForKeyframe = false
 			}
 		}

--- a/lib/playback/worker/video.ts
+++ b/lib/playback/worker/video.ts
@@ -4,7 +4,7 @@ import * as Message from "./message"
 
 interface DecoderConfig {
 	codec: string
-	description?: ArrayBuffer | TypedArray | DataView
+	description?: ArrayBuffer | Uint8Array | DataView
 	codedWidth?: number
 	codedHeight?: number
 	displayAspectWidth?: number

--- a/lib/playback/worker/video.ts
+++ b/lib/playback/worker/video.ts
@@ -2,12 +2,31 @@ import { Frame, Component } from "./timeline"
 import * as MP4 from "../../media/mp4"
 import * as Message from "./message"
 
+interface DecoderConfig {
+	codec: string
+	description?: ArrayBuffer | TypedArray | DataView
+	codedWidth?: number
+	codedHeight?: number
+	displayAspectWidth?: number
+	displayAspectHeight?: number
+	colorSpace?: {
+		primaries?: "bt709" | "bt470bg" | "smpte170m"
+		transfer?: "bt709" | "smpte170m" | "iec61966-2-1"
+		matrix?: "rgb" | "bt709" | "bt470bg" | "smpte170m"
+	}
+	hardwareAcceleration?: "no-preference" | "prefer-hardware" | "prefer-software" 
+	optimizeForLatency?: boolean
+}
+
 export class Renderer {
 	#canvas: OffscreenCanvas
 	#timeline: Component
 
 	#decoder!: VideoDecoder
 	#queue: TransformStream<Frame, VideoFrame>
+
+	#decoderConfig?: DecoderConfig
+	#waitingForKeyframe: boolean = true
 
 	constructor(config: Message.ConfigVideo, timeline: Component) {
 		this.#canvas = config.canvas
@@ -50,10 +69,28 @@ export class Renderer {
 	}
 
 	#transform(frame: Frame) {
+		if (this.#decoder.state === "closed") {
+			console.warn("Decoder is closed. Skipping frame.")
+			return
+		}
+
+		const { sample, track } = frame
+
+		// Reset the decoder on track change
+		if (this.#decoderConfig) {
+			const configMismatch = 
+			this.#decoderConfig.codec !== track.codec ||
+			this.#decoderConfig.codedWidth !== track.video.width ||
+			this.#decoderConfig.codedHeight !== track.video.height
+
+			if (configMismatch) {
+				this.#decoder.reset()
+				this.#decoderConfig = undefined
+			}
+		}
+
 		// Configure the decoder with the first frame
 		if (this.#decoder.state !== "configured") {
-			const { sample, track } = frame
-
 			const desc = sample.description
 			const box = desc.avcC ?? desc.hvcC ?? desc.vpcC ?? desc.av1C
 			if (!box) throw new Error(`unsupported codec: ${track.codec}`)
@@ -64,21 +101,41 @@ export class Renderer {
 
 			if (!MP4.isVideoTrack(track)) throw new Error("expected video track")
 
-			this.#decoder.configure({
+			this.#decoderConfig = {
 				codec: track.codec,
 				codedHeight: track.video.height,
 				codedWidth: track.video.width,
 				description,
 				// optimizeForLatency: true
-			})
+			}
+
+			this.#decoder.configure(this.#decoderConfig)
+			if(!frame.sample.is_sync){
+				this.#waitingForKeyframe = true
+			}else{
+				this.#waitingForKeyframe = false
+			}
 		}
 
-		const chunk = new EncodedVideoChunk({
-			type: frame.sample.is_sync ? "key" : "delta",
-			data: frame.sample.data,
-			timestamp: frame.sample.dts / frame.track.timescale,
-		})
+		//At the start of decode , VideoDecoder seems to expect a key frame after configure() or flush()
+		if (this.#decoder.state == "configured") {
+			if (this.#waitingForKeyframe && !frame.sample.is_sync) {
+				console.warn("Skipping non-keyframe until a keyframe is found.")
+				return
+			}
 
-		this.#decoder.decode(chunk)
+			// On arrival of a keyframe, allow decoding and stop waiting for a keyframe.
+			if (frame.sample.is_sync) {
+				this.#waitingForKeyframe = false
+			}
+
+			const chunk = new EncodedVideoChunk({
+				type: frame.sample.is_sync ? "key" : "delta",
+				data: frame.sample.data,
+				timestamp: frame.sample.dts / frame.track.timescale,
+			})
+
+			this.#decoder.decode(chunk)
+		}
 	}
 }

--- a/lib/transport/connection.ts
+++ b/lib/transport/connection.ts
@@ -55,6 +55,10 @@ export class Connection {
 		return this.#subscriber.subscribe(namespace, track)
 	}
 
+	unsubscribe(track: string) {
+		return this.#subscriber.unsubscribe(track)
+	}
+
 	subscribed() {
 		return this.#publisher.subscribed()
 	}

--- a/lib/transport/subscriber.ts
+++ b/lib/transport/subscriber.ts
@@ -18,6 +18,8 @@ export class Subscriber {
 	#subscribe = new Map<bigint, SubscribeSend>()
 	#subscribeNext = 0n
 
+	#trackToIDMap = new Map<string, bigint>()
+
 	constructor(control: Control.Stream, objects: Objects) {
 		this.#control = control
 		this.#objects = objects
@@ -66,6 +68,8 @@ export class Subscriber {
 		const subscribe = new SubscribeSend(this.#control, id, namespace, track)
 		this.#subscribe.set(id, subscribe)
 
+		this.#trackToIDMap.set(track, id)
+
 		await this.#control.send({
 			kind: Control.Msg.Subscribe,
 			id,
@@ -78,6 +82,19 @@ export class Subscriber {
 		})
 
 		return subscribe
+	}
+
+	async unsubscribe(track: string){
+		if (this.#trackToIDMap.has(track)) {
+			try{
+				await this.#control.send({kind: Control.Msg.Unsubscribe, id: this.#trackToIDMap.get(track) })
+				this.#trackToIDMap.delete(track)
+			} catch (error) {
+				console.error(`Failed to unsubscribe from track ${track}:`, error)
+			}
+		}else{
+			console.warn(`During unsubscribe request initiation attempt track ${track} not found in trackToIDMap.`)
+		}
 	}
 
 	recvSubscribeOk(msg: Control.SubscribeOk) {

--- a/lib/transport/subscriber.ts
+++ b/lib/transport/subscriber.ts
@@ -84,20 +84,20 @@ export class Subscriber {
 		return subscribe
 	}
 
-	async unsubscribe(track: string){
+	async unsubscribe(track: string) {
 		if (this.#trackToIDMap.has(track)) {
-			const trackID = this.#trackToIDMap.get(track);
+			const trackID = this.#trackToIDMap.get(track)
 			if (trackID === undefined) {
 				console.warn(`Exception track ${track} not found in trackToIDMap.`)
-				return					
+				return	
 			}
-			try{
-				await this.#control.send({kind: Control.Msg.Unsubscribe, id: trackID })
+			try {
+				await this.#control.send({ kind: Control.Msg.Unsubscribe, id: trackID })
 				this.#trackToIDMap.delete(track)
 			} catch (error) {
 				console.error(`Failed to unsubscribe from track ${track}:`, error)
 			}
-		}else{
+		} else {
 			console.warn(`During unsubscribe request initiation attempt track ${track} not found in trackToIDMap.`)
 		}
 	}

--- a/lib/transport/subscriber.ts
+++ b/lib/transport/subscriber.ts
@@ -89,7 +89,7 @@ export class Subscriber {
 			const trackID = this.#trackToIDMap.get(track)
 			if (trackID === undefined) {
 				console.warn(`Exception track ${track} not found in trackToIDMap.`)
-				return	
+				return
 			}
 			try {
 				await this.#control.send({ kind: Control.Msg.Unsubscribe, id: trackID })

--- a/lib/transport/subscriber.ts
+++ b/lib/transport/subscriber.ts
@@ -86,8 +86,13 @@ export class Subscriber {
 
 	async unsubscribe(track: string){
 		if (this.#trackToIDMap.has(track)) {
+			const trackID = this.#trackToIDMap.get(track);
+			if (trackID === undefined) {
+				console.warn(`Exception track ${track} not found in trackToIDMap.`)
+				return					
+			}
 			try{
-				await this.#control.send({kind: Control.Msg.Unsubscribe, id: this.#trackToIDMap.get(track) })
+				await this.#control.send({kind: Control.Msg.Unsubscribe, id: trackID })
 				this.#trackToIDMap.delete(track)
 			} catch (error) {
 				console.error(`Failed to unsubscribe from track ${track}:`, error)


### PR DESCRIPTION
The PR hosts the code changes to support the following:

- [x] Display available video tracks as a drop-down under the video , track names will be displayed in the drop-down.
    - With this [PR](https://github.com/TilsonJoji/moq-rs/pull/6)  , `dev/pub` script when "multi" is passed as an argument, 3 video tracks and an audio track will be ingested via moq-pub and on subscribing to the namespace , user will be able to see 3 video tracks as a drop-down

- [x] User can swap between video tracks by clicking on the track name in the dropdown , the video track will be changed without page refresh.
- [x] Subscribe to a particular track by appending the track in the URL or selecting a track from the dropdown list.

     - The current way to subscribe to a namespace , this would default subscribe to the first video track along with audio track
     - 	            https://SERVERIP:4321/watch/bbb?server=SERVERIP:4443

     - To subscribe to a specfic track , append the track number at the end of the URL as below:
     - 	            https://SERVERIP:4321/watch/bbb?server=SERVERIP:4443&track=1 [ Track number starts from 0 ] 

- [x] Tracks selected would be retained on page-reload.
- [x] Send unsubscribe request for a particular track to moq-relay.

    - When a new track is selected from the drop down , unsubscribe is sent to moq-relay for the current track and subscribe is sent to the selected track.
    - As of now relay responds with a code 1(SUBSRIBE_ERROR) , cancelled to an unsubscribe request from moq-js.
     - [ ] need to explore moq-rs on the same , to send the appropriate response on receiving unsubscribe from `moq-js`

- [x] During UT an error was encountered wherein VideoDecoder expects a key frame immediately after a configure() or flush() for a avc , changes were done to wait for keyframe after a configure , before the first call to decode. 
- [ ] Due to this initial wait for key frame , at times it takes few seconds for the video playback to start.
    - [ ] Need to explore if there are any alternate way to make VideoDecoder not demand a key frame immediately after a configure() or flush()
  